### PR TITLE
refactor(cli): config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ client-secret: "my-client-secret"
 customer-id: "my-customer-id"
 ```
 
-| **OS**  | **Default config locations**                            |
-|---------|---------------------------------------------------------|
-| linux   | `$HOME/.config/sbanken/config.yaml`                     |
-| darwin  | `$HOME/Library/Application Support/sbanken/config.yaml` |
-| windows | `%APPDATA%\sbanken\config.yaml`                         |
+| **OS**  | **Default config locations**                                                |
+|---------|-----------------------------------------------------------------------------|
+| linux   | `$XDG_CONFIG_HOME/sbanken/config.yaml`, `$HOME/.config/sbanken/config.yaml` |
+| darwin  | `$HOME/Library/Application Support/sbanken/config.yaml`                     |
+| windows | `%APPDATA%\sbanken\config.yaml`                                             |
 
 The config path can also be specified:
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
@@ -44,14 +43,12 @@ func New(ctx context.Context, conn sbankenConn, tw tableWriter, version string) 
 			configPath := c.String("config")
 
 			if configPath == "" {
-				switch runtime.GOOS {
-				case "linux":
-					configPath = fmt.Sprintf("%s/.config/sbanken/config.yaml", os.Getenv("HOME"))
-				case "darwin":
-					configPath = fmt.Sprintf("%s/Library/Application Support/sbanken/config.yaml", os.Getenv("HOME"))
-				case "windows":
-					configPath = fmt.Sprintf("%s/sbanken/config.yaml", os.Getenv("APPDATA"))
+				configDir, err := os.UserConfigDir()
+				if err != nil {
+					return err
 				}
+
+				configPath = fmt.Sprintf("%s/sbanken/config.yaml", configDir)
 			}
 
 			loadConfigFunc := altsrc.InitInputSourceWithContext(


### PR DESCRIPTION
Use `os.UserConfigDir` instead of hard coding the values.

Thanks for tip, @jimoe.